### PR TITLE
Various improvements for rpminspect_runner.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN dnf -y install \
     rpminspect-data-fedora-${RPMINSPECT_DATA_VERSION} \
     libabigail \
     koji \
+    xmlrpc-c-apps \
     && dnf clean all
 
 COPY rpminspect_runner.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN dnf -y install \
     rpminspect-data-fedora-${RPMINSPECT_DATA_VERSION} \
     libabigail \
     koji \
-    xmlrpc-c-apps \
+    jq \
     && dnf clean all
 
 COPY rpminspect_runner.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN dnf -y install \
     rpminspect-data-fedora-${RPMINSPECT_DATA_VERSION} \
     libabigail \
     koji \
-    jq \
+    xmlrpc-c-apps \
     && dnf clean all
 
 COPY rpminspect_runner.sh /usr/local/bin/

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -11,8 +11,10 @@
 # OUTPUT_FORMAT - rpminspect output format (text, json, xunit)
 # RPMINSPECT_WORKDIR - workdir where to cache downloaded builds
 # KOJI_BIN - path where to find "koji" binary
+# KOJI_HUB - XML-RPC Koji hub URL (defaults to server line in /etc/koji.conf)
 
 set -e
+PATH=/usr/bin:/usr/sbin
 
 trap fix_rc EXIT SIGINT SIGSEGV
 fix_rc() {
@@ -33,6 +35,26 @@ fix_rc() {
 
 config=${RPMINSPECT_CONFIG:-/usr/share/rpminspect/fedora.yaml}
 koji_bin=${KOJI_BIN:-/usr/bin/koji}
+hub=
+
+# use provided Koji hub or try the one in koji.conf
+if [ -z "${KOJI_HUB}" ]; then
+    [ -f /etc/koji.conf ] && hub="$(grep ^server /etc/koji.conf | awk '{ print $3; }')"
+else
+    hub="${KOJI_HUB}"
+fi
+
+# make sure we have a Koji hub
+if [ -z "${hub}" ]; then
+    echo "*** missing Koji hub" >&2
+    exit 3
+fi
+
+# make sure the Koji hub is up, exit if not
+if ping -q -c 1 -w 15 "${KOJI_HUB}" >/dev/null 2>&1 ; then
+    echo "*** Koji hub '${KOJI_HUB}' is not reachable" >&2
+    exit 4
+fi
 
 task_id=${1}
 previous_tag=${2}
@@ -49,9 +71,11 @@ get_name_from_nvr() {
     # Params:
     # $1: NVR
     nvr=$1
-    # Pfff... close your eyes here...
-    # shellcheck disable=SC2001
-    name=$(echo "${nvr}" | sed 's/^\(.*\)-\([^-]\{1,\}\)-\([^-]\{1,\}\)$/\1/')
+    kojioutput="$(mktemp)"
+    xmlrpc "${hub}" getBuild s/"${nvr}" > "${kojioutput}"
+    nameline=$(grep -n "'name'$" "${kojioutput}" | cut -d ':' -f 1)
+    name="$(head -n $((nameline + 1)) "${kojioutput}" | tail -n 1 | cut -d "'" -f 2)"
+    rm -f "${kojioutput}"
     echo -n "${name}"
 }
 

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -34,6 +34,7 @@ fix_rc() {
 
 config=${RPMINSPECT_CONFIG:-/usr/share/rpminspect/fedora.yaml}
 koji_bin=${KOJI_BIN:-/usr/bin/koji}
+koji_brand="$(basename "${koji_bin}")"
 
 task_id=${1}
 previous_tag=${2}
@@ -59,7 +60,7 @@ get_after_build() {
     # Params:
     # $1: task id
     task_id=$1
-    after_build=$(${koji_bin} taskinfo "${task_id}" | grep Build | awk -F' ' '{ print $2 }')
+    after_build="$(${koji_bin} call --json-output listBuilds taskId="${task_id}" | jq -r '.[0] .nvr')"
     echo -n "${after_build}"
 }
 


### PR DESCRIPTION
Fix up warnings from shellcheck.  Change get_name_from_nvr() to speak to the Koji hub using xmlrpc.  Since Koji already knows the package name, that's the better option to use IMHO and less risk for failures for package names we have not seen yet.

What I want to really do is send a PR to koji for the buildinfo command to extend what it outputs.  But later.