### PR TITLE
Clean up around RPMINSPECT_WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,6 @@ LABEL description="rpminspect for fedora-ci"
 ENV RPMINSPECT_PACKAGE_NAME=rpminspect
 ENV RPMINSPECT_DATA_PACKAGE_NAME=rpminspect-data-fedora
 
-ENV RPMINSPECT_WORKDIR=/workdir/
-ENV HOME=${RPMINSPECT_WORKDIR}
-
-RUN mkdir -p ${RPMINSPECT_WORKDIR} &&\
-    chmod 777 ${RPMINSPECT_WORKDIR}
-
 RUN dnf -y install 'dnf-command(copr)' && \
     dnf -y copr enable dcantrell/rpminspect
 
@@ -31,5 +25,3 @@ RUN dnf install -y --enablerepo=updates-testing \
 RUN freshclam
 
 COPY *.sh scripts/rpminspect_json2text.py /usr/local/bin/
-
-WORKDIR ${RPMINSPECT_WORKDIR}


### PR DESCRIPTION
This was confusing as it wasn't actually doing
what one was expecting it to be doing.
rpminspect was not using it as its workdir, because it was not called with --workdir param.
Instead, the directory was only used as a cache for results.

Also, tmt ignores the container workdir altogether and instead calls the runner script in its own directory.

This commit makes the workdir relative to $PWD and tells rpminspect to actually use it.

Signed-off-by: Michal Srb <michal@redhat.com>