### PR TITLE
Expose result.json and verbose.log as TMT artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ logs/
 cache/
 scripts/cache/
 scripts/results_cache/
-results.json
+result.json
 rpminspect.yaml

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -219,7 +219,7 @@ if [ ! -f "${results_cached_file}" ]; then
     # Update the data package, but from COPR, not from the official Fedora repositories
     dnf update --disablerepo="fedora*" -y ${RPMINSPECT_PACKAGE_NAME} ${RPMINSPECT_DATA_PACKAGE_NAME} > update_rpminspect.log 2>&1 || :
 
-    output_filename=results.json
+    output_filename=result.json
     # Workdir used by rpminspect
     workdir="${PWD}/workdir/"
     mkdir -p "${workdir}"

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -219,7 +219,8 @@ if [ ! -f "${results_cached_file}" ]; then
     # Update the data package, but from COPR, not from the official Fedora repositories
     dnf update --disablerepo="fedora*" -y ${RPMINSPECT_PACKAGE_NAME} ${RPMINSPECT_DATA_PACKAGE_NAME} > update_rpminspect.log 2>&1 || :
 
-    output_filename=result.json
+    output_filename=${TMT_TEST_DATA:-.}/result.json
+    verbose_log=${TMT_TEST_DATA:-.}/verbose.log
     # Workdir used by rpminspect
     workdir="${PWD}/workdir/"
     mkdir -p "${workdir}"
@@ -235,7 +236,7 @@ if [ ! -f "${results_cached_file}" ]; then
             ${tests:+--tests=$tests} \
             ${before_build} \
             ${after_build_param} \
-            > verbose.log 2>&1 || :
+            > $verbose_log 2>&1 || :
 
     rm -Rf "${workdir}"
 
@@ -245,7 +246,7 @@ if [ ! -f "${results_cached_file}" ]; then
         touch "${results_cached_file}"
     else
         # rpminspect probably crashed... let's just show the verbose.log
-        cat verbose.log
+        cat $verbose_log
         exit 123  # error
     fi
 fi

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -53,6 +53,10 @@ is_module="${IS_MODULE}"
 
 tests="${TESTS}"
 
+# support running out of git tree
+MYDIR="$(dirname $(realpath "$0"))"
+export PATH="$PATH:$MYDIR:$MYDIR/scripts"
+
 get_name_from_nvr() {
     # Extract package name (N) from NVR.
     # Params:

--- a/scripts/run_rpminspect.sh
+++ b/scripts/run_rpminspect.sh
@@ -21,7 +21,7 @@ cat rpminspect.yaml || :
 
 "${RPMINSPECT_BIN}" \
     --format=json \
-    --output=results.json \
+    --output=result.json \
     --verbose \
     ${RPMINSPECT_PROFILE:+--profile=$RPMINSPECT_PROFILE} \
     ${RPMINSPECT_DEFAULT_RELEASE_STRING:+--release=$RPMINSPECT_DEFAULT_RELEASE_STRING} \
@@ -29,6 +29,6 @@ cat rpminspect.yaml || :
     "${after_build_dir}" || :
 
 # Convert JSON to text and store results of each inspection to a separate file
-if [ -f "results.json" ]; then
-    python3 "${script_dir}/rpminspect_json2text.py" "${results_cache_dir}" results.json
+if [ -f "result.json" ]; then
+    python3 "${script_dir}/rpminspect_json2text.py" "${results_cache_dir}" result.json
 fi


### PR DESCRIPTION
TF stopped archiving the full built source tree [1] to save a lot of
space. That caused result.json and verbose.log to not get save as
artifacts any more. As these are are useful, put them into
`$TMT_TEST_DATA`, which is the official directory for artifacts.

[1] https://gitlab.com/testing-farm/infrastructure/-/merge_requests/95

----

Plus a few more small cleanups. I broke this out of PR #80 as that is still being discussed; these commits here should be the simple bits.