### PR TITLE
Expose custom package configuration as artifact

### DIFF
--- a/rpminspect_get_local_config.sh
+++ b/rpminspect_get_local_config.sh
@@ -69,8 +69,9 @@ if [ ! -f "rpminspect.yaml" ]; then
         popd
 
         # and finally, copy the config to the current directory;
-        # or create an empty one if missing in the repository
-        cp "${tmp_dir}/rpminspect.yaml" . || echo "inspections: {}" > rpminspect.yaml
+        if [ -f "${tmp_dir}/rpminspect.yaml" ]; then
+            cp cp "${tmp_dir}/rpminspect.yaml" .
+        fi
         rm -Rf "${tmp_dir}"
     ) >> clone.log 2>&1
 fi

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -251,6 +251,11 @@ if [ -n "$TMT_TEST_DATA" ]; then
     - data/rpminspect/data/verbose.log
     - data/rpminspect/data/result.json
 EOF
+    # if dist-git uses a custom rpminspect config, add that as an artifact as well
+    if [ -e rpminspect.yaml ]; then
+        cp rpminspect.yaml "$TMT_TEST_DATA"
+        echo "    - data/rpminspect/data/rpminspect.yaml" >> "$TMT_TEST_DATA/results.yaml"
+    fi
     echo "running in TMT, wrote $TMT_TEST_DATA/results.yaml"
 fi
 


### PR DESCRIPTION
Some packages use a custom `rpminspect.yaml` in their dist-git. If it exists, attach it as an additional artifact.

Drop the empty default rpminspect.yaml, as we don't want to attach that. rpminspect does not require this.

Fixes [OSCI-3997](https://issues.redhat.com/browse/OSCI-3997)

----

For testing, I fed this through Jenkins via https://github.com/fedora-ci/rpminspect-pipeline/pull/67:

 -  tin package without a custom rpminspect.yaml -- [latest update](https://bodhi.fedoraproject.org/updates/FEDORA-2022-46ddab837f) on its [latest build](https://koji.fedoraproject.org/koji/taskinfo?taskID=95557861) which has a [failed rpminspec run](https://artifacts.dev.testing-farm.io/47780cdf-8bbb-41c3-9267-8ece9a0a9be9/). The [result](https://artifacts.dev.testing-farm.io/8a0acbb9-256a-4449-bfee-0bf80ca22572/) from the [Jenkins run](https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/rpminspect-pipeline/view/change-requests/job/PR-67/3) looks exactly the same, as expected. That proves that we don't need an almost-empty default `rpminspect.yaml`.

 - systemd package with a [custom rpminspect.yaml](https://src.fedoraproject.org/rpms/systemd/blob/rawhide/f/rpminspect.yaml) on its [latest update](https://bodhi.fedoraproject.org/updates/FEDORA-2022-7f1889cc8c) with [latest build](https://koji.fedoraproject.org/koji/taskinfo?taskID=95105450), which also has a [failed rpminspect result](https://artifacts.dev.testing-farm.io/6688aff8-c777-4527-a4af-8a24483651f5/). The [Jenkins run](https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/rpminspect-pipeline/view/change-requests/job/PR-67/2) for this PR produced a [result](https://artifacts.dev.testing-farm.io/b5c64466-c472-4590-9d1e-3e93b6e6c6b2/) with comparable outputs (it uses the new viewer), and most importantly it has the `rpminspect.yaml` artifact.