### PR TITLE
Fix `cp` typo in rpminspect_get_local_config.sh

### DIFF
--- a/rpminspect_get_local_config.sh
+++ b/rpminspect_get_local_config.sh
@@ -70,7 +70,7 @@ if [ ! -f "rpminspect.yaml" ]; then
 
         # and finally, copy the config to the current directory;
         if [ -f "${tmp_dir}/rpminspect.yaml" ]; then
-            cp cp "${tmp_dir}/rpminspect.yaml" .
+            cp "${tmp_dir}/rpminspect.yaml" .
         fi
         rm -Rf "${tmp_dir}"
     ) >> clone.log 2>&1


### PR DESCRIPTION
Introduced in commit fc8f7378b7. That's what you get with scripts which aren't `set -e`..

---

@msrb Sorry about that!