### PR TITLE
Support the ? delimiter in the koji Source

### DIFF
--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -186,8 +186,8 @@ else
 fi
 
 repo_ref=$("${koji_bin}" buildinfo "${after_build}" | grep "^Source: " | awk '{ print $2 }' | sed 's|^git+||')
-repo_url=$(echo "${repo_ref}" | awk -F'#' '{ print $1 }')
-commit_ref=$(echo "${repo_ref}" | awk -F'#' '{ print $2 }')
+repo_url=$(echo "${repo_ref}" | awk -F'#' '{ print $1 }' | awk -F'?' '{ print $1 }'))
+commit_ref=$(echo "${repo_ref}" | awk -F'#' '{ print $2 }' | awk -F'?' '{ print $1 }')
 
 fetch-my-conf.py "${repo_url}" "${CONFIG_BRANCHES}" "${commit_ref}" || :
 


### PR DESCRIPTION
It seems the Source can be also in following format:

```
git://something/modules/idm?#0a51b0f59c2af33e7868126c4a033402f122a832
```

The `?` character confuses current code. The `repo_ref` in this case is `git://something/modules/idm?` which is wrong and the code fails later to clone this repo.

In this commit, another `awk` call is executed to remove this character. There are multiple ways how to do it, this one was just first one I found out reading the current code.

As a result, the `repo_url` does not contain that question mark character and the cloning should succeed.