### PR TITLE
 Make ClamAV virus database updates more robust 

### DIFF
--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -155,6 +155,8 @@ get_before_module_build() {
 }
 
 
+freshclam_log=${TMT_TEST_DATA:-.}/freshclam.log
+
 update_clamav_database() {
     # Update the virus dababase
     config_file="freshclam.conf"
@@ -163,12 +165,12 @@ update_clamav_database() {
         sed -i "s|^DatabaseMirror .*|DatabaseMirror $CLAMAV_DATABASE_MIRROR_URL|" "$config_file"
     fi
 
-    freshclam --config-file="$config_file" > freshclam.log 2>&1 || :
+    freshclam --config-file="$config_file" > "$freshclam_log" 2>&1 || :
     # freshclam returns 0 even if the update download fails
     # https://github.com/Cisco-Talos/clamav/issues/965
     # Let's check the log for the complaint about the outdated database
     # and return non-zero if we find it there
-    ! grep -q 'virus database is older' freshclam.log
+    ! grep -q 'virus database is older' "$freshclam_log"
 }
 
 


### PR DESCRIPTION
See: OSCI-6251

freshclam will try to download incremental patches, but if one
or more patches are missing, it will update the database only
partially. If we then try to run freshclam again, it will try
to download the whole daily.cvd file.

If even the second run fails, we will continue with the older
version of the database.