### PR TITLE
Don't update annobin

### DIFF
--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -230,11 +230,6 @@ if ! update_clamav_database; then
     update_clamav_database || :
 fi
 
-# Update annobin
-# FIXME: we don't want to touch packages when the base image is Rawhide...
-#     We can uncomment this once the latest annocheck can be installed from a stable repo.
-#dnf update -y annobin* > update_annobin.log 2>&1 || :
-
 # Update the data packages, but from COPR, not from the official Fedora repositories
 dnf -y update --disablerepo="fedora*" "${RPMINSPECT_PACKAGE_NAME}" "${RPMINSPECT_DATA_PACKAGE_NAME}" fedora-license-data > update_rpminspect.log 2>&1 || :
 


### PR DESCRIPTION
I am a bit confused about why this is set up as it is. The code says:
```
we don't want to touch packages when the base image is Rawhide...
```
Why is this? If we're after stability, why aren't we using the F40 image?

If we want bleeding-edge but only when we say so, would it be better to use the F40 image and pull `annocheck` from COPR like we do for some other `rpminspect`-ish packages?

I'm not sure what the reasoning is behind this, so the MR currently just updates `annobin` to the latest version which will solve the problem I'm looking at. If we want to do something different then sure, I just would like to understand it :smile: 