### PR TITLE
Upload PR jobs to Github registry

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -8,7 +8,7 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build Image
         uses: redhat-actions/buildah-build@v2
         with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -9,11 +9,22 @@ jobs:
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Gather metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: quay.io/fedoraci/rpminspect
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
       - name: Build Image
         uses: redhat-actions/buildah-build@v2
         with:
           image: quay.io/fedoraci/rpminspect
-          tags: latest ${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
           containerfiles: |
             ./Dockerfile
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,5 +1,10 @@
 name: Image build and push
 on: [push, pull_request]
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   image-build-and-push:
     runs-on: ubuntu-latest
@@ -22,9 +27,19 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build Image
         uses: redhat-actions/buildah-build@v2
+        id: build
         with:
           image: quay.io/fedoraci/rpminspect
           tags: ${{ steps.meta.outputs.tags }}
           containerfiles: |
             ./Dockerfile
+      - name: Push to GitHub Image registry
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build.outputs.image }}
+          tags: ${{ steps.build.outputs.tags }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'pull_request' }}
       - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
In order to make it easier to work on this pipeline, I suggest to use the Github image registry to so that `rpminspect-pipeline` can reference it in the tmt reference. I will need this in order to check how to allow `packit` jobs to use this tmt job as well (probably merging [`packit-plans` implementation](https://github.com/packit/tmt-plans/blob/main/tests/rpminspect/rpminspect.sh))